### PR TITLE
Update pausemenu_cl.lua

### DIFF
--- a/client/pausemenu_cl.lua
+++ b/client/pausemenu_cl.lua
@@ -6,16 +6,19 @@
 Citizen.CreateThread(function()
 	while true do
 	    Wait(1)
-		SetPauseMenuActive(false)
-	    if (IsControlJustPressed(0, 200)) then
-            TransitionToBlurred(1000)
-            SetNuiFocus(true, true)
-            SendNUIMessage({
-            open = true
-            })
-		end
+	    SetPauseMenuActive(false)
+
+	    -- Check if the in-game pause menu is NOT active before opening the custom menu
+	    if not IsPauseMenuActive() and IsControlJustPressed(0, 200) then
+	        TransitionToBlurred(1000)
+	        SetNuiFocus(true, true)
+	        SendNUIMessage({
+	            open = true
+	        })
+	    end
 	end
 end)
+
 -- Function to close menu
 function ClosePause()
 	TransitionFromBlurred(1000)


### PR DESCRIPTION
Checks for settings menu to be active before it re-opens.. so it doesn't take multiple attempts.